### PR TITLE
Add file monitoring of ld.so.preload for injection

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -194,6 +194,9 @@
 ## Library search paths
 -w /etc/ld.so.conf -p wa -k libpath
 
+## Systemwide library preloads (LD_PRELOAD)
+-w /etc/ld.so.preload -p wa -k systemwide_preloads
+
 ## Pam configuration
 -w /etc/pam.d/ -p wa -k pam
 -w /etc/security/limits.conf -p wa  -k pam


### PR DESCRIPTION
/etc/ld.so.preload defines shared object libraries for preload by the dynamic linker system-wide. This file is seldom touched in most environments and does not typically exist by default.