### PR TITLE
Add /etc/sudoers.d/ directory

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -10,7 +10,7 @@
 # Compiled by Florian Roth
 # 
 # Created  : 2017/12/05 
-# Modified : 2018/08/05
+# Modified : 2019/11/26
 # 
 # Based on rules published here:
 #   Gov.uk auditd rules
@@ -154,6 +154,7 @@
 
 ## Sudoers file changes
 -w /etc/sudoers -p wa -k actions
+-w /etc/sudoers.d/ -p wa -k actions
 
 ## Passwd
 -w /usr/bin/passwd -p x -k passwd_modification


### PR DESCRIPTION
Could be useful to watch `/etc/suders.d/` according to `man sudoers`:

> The #includedir directive can be used to create a sudo.d directory that the system package manager can drop sudoers rules into as part of package installation. For example, given:
> 
> sudo will read each file in /etc/sudoers.d, skipping file names that end in '~' or contain a '.' character to avoid causing problems with package manager or editor temporary/backup files.