### PR TITLE
Add a rule for Netcat

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -309,6 +309,7 @@
 
 ## Added to catch netcat on Ubuntu
 -w /bin/nc.openbsd -p x -k susp_activity
+-w /bin/nc.traditional -p x -k susp_activity
 
 ## Sbin suspicious activity
 -w /sbin/iptables -p x -k sbin_susp 


### PR DESCRIPTION
Could be useful to also watch /bin/nc.traditional.

Indeed in Debian, it is the binary executed when netcat is called