### PR TITLE
Move general tracing rules to end of block

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -336,14 +336,14 @@
 ## Injection
 ### These rules watch for code injection by the ptrace facility.
 ### This could indicate someone trying to do something bad or just debugging
--a always,exit -F arch=b32 -S ptrace -k tracing
--a always,exit -F arch=b64 -S ptrace -k tracing
 -a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k code_injection
 -a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k code_injection
 -a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k data_injection
 -a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k data_injection
 -a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k register_injection
 -a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k register_injection
+-a always,exit -F arch=b32 -S ptrace -k tracing
+-a always,exit -F arch=b64 -S ptrace -k tracing
 
 ## Privilege Abuse
 ### The purpose of this rule is to detect when an admin may be abusing power by looking in user's home dir.


### PR DESCRIPTION
First match will trigger rule - the different injection rules are never hit.