### PR TITLE
Added rule to detect invocations of dbus-send, key dbus_send. Helps d…

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -343,6 +343,10 @@
 -w /usr/sbin/traceroute -p x -k sbin_susp
 -w /usr/sbin/ufw -p x -k sbin_susp
 
+## dbus-send invocation
+### may indicate privilege escalation CVE-2021-3560
+-w /usr/bin/dbus-send -p x -k dbus_send
+
 ## Injection
 ### These rules watch for code injection by the ptrace facility.
 ### This could indicate someone trying to do something bad or just debugging


### PR DESCRIPTION
…etecting CVE-2021-3560.

Tested the rule with CentOS 8 and Ubuntu 20.04 (both vulnerable). dbus-send doesn't seem to be used under normal operations, so the rule should be a low volume one.

While dbus-send can be easily detected, the overall exploit is *very* noisy when it comes to audit logging (tons of user/group modifications and more). 