### PR TITLE
Don't drop EOE messages in kernel -> user-space communication

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -70,9 +70,6 @@
 ## Ignore current working directory records
 -a always,exclude -F msgtype=CWD
 
-## Ignore EOE records (End Of Event, not needed)
--a always,exclude -F msgtype=EOE
-
 ## Cron jobs fill the logs with stuff we normally don't want (works with SELinux)
 -a never,user -F subj_type=crond_t
 -a never,exit -F subj_type=crond_t


### PR DESCRIPTION
While it is true that end-of-event messages are technically not needed
for the regular audit log, auditd will filter them out anyway (cf.
https://github.com/linux-audit/audit-userspace/blob/0f79b322856ad6f40aa7d0291c2ebc4947543057/src/auditd.c#L276).
However, auditd does forward EOE messages to audit dispatcher plugins
such as Laurel which may rely on those mesages being
there. (<https://github.com/threathunters-io/laurel/issues/14>.)