### PR TITLE
Added rules for memfd_create to detect possible "fileless binary execution"

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -386,6 +386,14 @@
 -a always,exit -F arch=b32 -S ptrace -k tracing
 -a always,exit -F arch=b64 -S ptrace -k tracing
 
+## Anonymous File Creation
+### These rules watch the use of memfd_create 
+### "memfd_create" creates anonymous file and returns a file descriptor to access it
+### When combined with "fexecve" can be used to stealthily run binaries in memory without touching disk  
+-a always,exit -F arch=b64 -S memfd_create -F key=anon_file_create
+-a always,exit -F arch=b32 -S memfd_create -F key=anon_file_create      
+
+
 ## Privilege Abuse
 ### The purpose of this rule is to detect when an admin may be abusing power by looking in user's home dir.
 -a always,exit -F dir=/home -F uid=0 -F auid>=1000 -F auid!=-1 -C auid!=obj_uid -k power_abuse


### PR DESCRIPTION
Why should there be rules for `memfd_create`?
With the research [here](https://x-c3ll.github.io/posts/fileless-memfd_create/) and [here](https://0x00sec.org/t/super-stealthy-droppers/3715) regarding super stealthy linux droppers, they both run on the presumption running purely in memory will be hard to detect because of the lack of touching disk.

The best counter to not touching disk is making `memfd_create` touch disk. Via rules in auditd, each `memfd_create` call would have to leave a forensic fingerprint in the form of logs on disk.

Note:
Additional rules could be implemented as mentioned [here](https://magisterquis.github.io/2018/03/31/in-memory-only-elf-execution.html) that would notice the calls to `/proc/<PID>/exe` via looking at all args to `execve`. However, that would be very high overhead to verify every execve call is not touching `/proc` so I excluded it.