### PR TITLE
Update audit.rules

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -598,8 +598,8 @@
 ## Remove them if they cause to much volume in your environment
 
 ## Root command executions
--a always,exit -F arch=b64 -F euid=0 -S execve -k rootcmd
--a always,exit -F arch=b32 -F euid=0 -S execve -k rootcmd
+-a always,exit -F arch=b64 -F euid=0 -F auid>=1000 -F auid!=4294967295 -S execve -k rootcmd
+-a always,exit -F arch=b32 -F euid=0 -F auid>=1000 -F auid!=4294967295 -S execve -k rootcmd
 
 ## File Deletion Events by User
 -a always,exit -F arch=b32 -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=-1 -k delete


### PR DESCRIPTION
I believe that this rule is much more useful as a 'best practice' for auditd root commands. It gets rid of all the 'noise' and ONLY provides alerts from users who are actually running sudo commands. More info here: https://sudoedit.com/log-sudo-with-auditd/ - When I put this in my rules I went from thousands of alerts in minutes to only specific sudo commands being ran.