### PR TITLE
Fixed syntax errors

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -551,7 +551,7 @@
 ## https://wiki.archlinux.org/title/Pacman
 ## T1072 third party software
 -w /etc/pacman.conf -p x -k T1072_third_party_software
--w /etc//etc/pacman.d -p x -k T1072_third_party_software
+-w /etc/pacman.d -p x -k T1072_third_party_software
    
 # Special Software ------------------------------------------------------------
 
@@ -634,34 +634,34 @@
 # /usr/include/linux/ipc.h
 
 ## msgctl
-#-a entry,always -S ipc -F a0=14 -k T1559_Inter-Process_Communication
+#-a always,exit -S ipc -F a0=14 -k T1559_Inter-Process_Communication
 ## msgget
-#-a entry,always -S ipc -F a0=13 -k T1559_Inter-Process_Communication
+#-a always,exit -S ipc -F a0=13 -k T1559_Inter-Process_Communication
 ## Use these lines on x86_64, ia64 instead
--a entry,always -S msgctl -k T1559_Inter-Process_Communication
--a entry,always -S msgget -k T1559_Inter-Process_Communication
+-a always,exit -F arch=b64 -S msgctl -k T1559_Inter-Process_Communication
+-a always,exit -F arch=b64 -S msgget -k T1559_Inter-Process_Communication
 
 ## semctl
-#-a entry,always -S ipc -F a0=3 -k T1559_Inter-Process_Communication
+#-a always,exit -S ipc -F a0=3 -k T1559_Inter-Process_Communication
 ## semget
-#-a entry,always -S ipc -F a0=2 -k T1559_Inter-Process_Communication
+#-a always,exit -S ipc -F a0=2 -k T1559_Inter-Process_Communication
 ## semop
-#-a entry,always -S ipc -F a0=1 -k T1559_Inter-Process_Communication
+#-a always,exit -S ipc -F a0=1 -k T1559_Inter-Process_Communication
 ## semtimedop
-#-a entry,always -S ipc -F a0=4 -k T1559_Inter-Process_Communication
+#-a always,exit -S ipc -F a0=4 -k T1559_Inter-Process_Communication
 ## Use these lines on x86_64, ia64 instead
--a entry,always -S semctl -k T1559_Inter-Process_Communication
--a entry,always -S semget -k T1559_Inter-Process_Communication
--a entry,always -S semop -k T1559_Inter-Process_Communication
--a entry,always -S semtimedop -k T1559_Inter-Process_Communication
+-a always,exit -F arch=b64 -S semctl -k T1559_Inter-Process_Communication
+-a always,exit -F arch=b64 -S semget -k T1559_Inter-Process_Communication
+-a always,exit -F arch=b64 -S semop -k T1559_Inter-Process_Communication
+-a always,exit -F arch=b64 -S semtimedop -k T1559_Inter-Process_Communication
 
 ## shmctl
-#-a entry,always -S ipc -F a0=24 -k T1559_Inter-Process_Communication
+#-a always,exit -S ipc -F a0=24 -k T1559_Inter-Process_Communication
 ## shmget
-#-a entry,always -S ipc -F a0=23 -k T1559_Inter-Process_Communication
+#-a always,exit -S ipc -F a0=23 -k T1559_Inter-Process_Communication
 ## Use these lines on x86_64, ia64 instead
--a entry,always -S shmctl -k T1559_Inter-Process_Communication
--a entry,always -S shmget -k T1559_Inter-Process_Communication
+-a always,exit -F arch=b64 -S shmctl -k T1559_Inter-Process_Communication
+-a always,exit -F arch=b64 -S shmget -k T1559_Inter-Process_Communication
 
 # High Volume Events ----------------------------------------------------------
 


### PR DESCRIPTION
Fixed syntax errors in the following sections:

- Pacman
- ipc system call

Revised all `entry` rules to be `exit` rules

- https://github.com/linux-audit/audit-userspace/blob/7e156d2b0ff6bbbb503562760b24976458eb2133/docs/audit.rules.7#L163


Tested on:
- Fedora 35, auditd version 3.0.8-1.fc35
- Debian 11, auditd version 1:3.0-2
- Ubuntu 20.04, auditd version 1:2.8.5-2ubuntu6
- Ubuntu Server 22.04, auditd version 1:3.0.7-build1

Tested with:
```bash
rm /etc/audit/rules.d/*
auditctl -D
cp <rules> /etc/audit/rules.d/
augenrules --load # check for errors
auditctl -l # check for all rules
```

With `entry,always` `augenrules --load` returns:
```
Append rule - bad keyword entry,always
```

Without `-F arch=b64` `augenrules --load` returns:
```
WARNING - 32/64 bit syscall mismatch in line <line>, you should specify an arch
```