### PR TITLE
added rules to detect remote shell usage

### DIFF
--- a/reverse_shell.rules
+++ b/reverse_shell.rules
@@ -1,0 +1,6 @@
+###Can be used to detect Remote Shell Use. Note the comm files in logs are of high value###
+
+-a always,exit -F arch=b64  -F exe=/bin/bash -F success=1 -S connect -k "remote_shell"
+-a always,exit -F arch=b64  -F exe=/usr/bin/bash -F success=1 -S connect -k "remote_shell"
+-a always,exit -F arch=b32  -F exe=/bin/bash -F success=1 -S connect -k "remote_shell"
+-a always,exit -F arch=b32  -F exe=/usr/bin/bash -F success=1 -S connect -k "remote_shell"


### PR DESCRIPTION
Currently can be caught in the network traffic rules. However if those can not be used due to log volume or if it is easier to see a more targeted rule this can be used to detect remote shell usage. Previously has been helpful detecting reverse bash shell usage.