### PR TITLE
Update test-rules.yml

### DIFF
--- a/.github/workflows/test-rules.yml
+++ b/.github/workflows/test-rules.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - patch-2
   pull_request:
     branches:
       - master

--- a/.github/workflows/test-rules.yml
+++ b/.github/workflows/test-rules.yml
@@ -5,9 +5,12 @@ name: Auditd Syntax Checks
 on:
   # Triggers the workflow on push or pull request events but only for the "master" branch
   push:
-    branches: [ "master" ]
+    branches:
+      - master
+      - patch-2
   pull_request:
-    branches: [ "master" ]
+    branches:
+      - master
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -21,15 +24,31 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
-      - name: Install auditd
-        run: sudo apt-get install -y auditd
+      - name: Update package information
+        run: sudo apt update
 
-      - name: Copy the new rules to the right location
+      - name: Install auditd
+        run: sudo apt install -y auditd
+
+      - name: Start auditd
+        run: if ! (systemctl is-active auditd); then sudo systemctl start auditd; fi
+
+      - name: Remove default rules
         run: |
-          sudo auditctl -D
-          sudo cp $GITHUB_WORKSPACE/audit.rules /etc/audit/audit.rules
-          
-      - name: Check the rules for errors
-        run: |          
-          sudo augenrules --load # check for errors
-          sudo auditctl -l # check for all rules
+          sudo ls -l /etc/audit/rules.d/
+          sudo rm /etc/audit/audit.rules
+          sudo rm -rf /etc/audit/rules.d
+          sudo mkdir /etc/audit/rules.d
+
+      - name: Copy rules file to rules directory
+        run: sudo cp $GITHUB_WORKSPACE/audit.rules /etc/audit/rules.d/
+
+      - name: Check rules
+        run: sudo augenrules --check 2>&1
+
+      # This will load the compiled rules file, check how many lines are in it, and display each line if successful
+      - name: Load rules
+        run: |
+          sudo augenrules --load 2>&1
+          sudo wc -l /etc/audit/audit.rules
+          sudo auditctl -l


### PR DESCRIPTION
I took notice the rules weren't being loaded and displayed in the GitHub Actions logs. I also ran into the same issue.

The additional steps just make sure the latest version of auditd is running and any default rule files that may come with auditd are removed before the custom rules are loaded. It also gets a line count of the compiled `/etc/audit/audit.rules` file after `augenrules --load` is executed.

It may be specific to Ubuntu and Fedora, but `augenrules --load` seems to want to read from files under `/etc/audit/rules.d/*` to compile the `/etc/audit/audit.rules` file.

There are some errors in the results with a few lines that are incompatible with the Ubuntu runner, but otherwise all the compatible rules appear to load and run without issue. I checked this by repeating the same steps in a 20.04 VM with the rules file in this repo.

It would be interesting if there was a way to leverage docker on the runners to test other Linux distros in additon to macOS. Not sure if this is possible, but I'll need to try this.