### PR TITLE
add pipx python method of installing third party software

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -518,6 +518,8 @@
 -w /usr/local/bin/pip -p x -k T1072_third_party_software
 -w /usr/bin/pip3 -p x -k T1072_third_party_software
 -w /usr/local/bin/pip3 -p x -k T1072_third_party_software
+-w /usr/bin/pipx -p x -k T1072_third_party_software
+-w /usr/local/bin/pipx -p x -k T1072_third_party_software
 
 # npm
 ## T1072 third party software


### PR DESCRIPTION
Python package installations should be more common with pipx because of [PEP 668 – Marking Python base environments as “externally managed” | peps.python.org](https://peps.python.org/pep-0668/)