### PR TITLE
Only trigger write actions on docker volumes

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -615,7 +615,7 @@
 -w /usr/bin/docker -k docker
 -w /usr/bin/docker-containerd -k docker
 -w /usr/bin/docker-runc -k docker
--w /var/lib/docker -k docker
+-w /var/lib/docker -p wa -k docker
 -w /etc/docker -k docker
 -w /etc/sysconfig/docker -k docker
 -w /etc/sysconfig/docker-storage -k docker


### PR DESCRIPTION
The current rule:
-w /var/lib/docker -k docker

will create a lot of logs on hosts running docker because the watched path includes the docker volumes so that actions inside any container running on the hosts will trigger the rule.

This will change to rule to only trigger on file changes