### PR TITLE
fix: do not ignore AVC messages

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -74,9 +74,6 @@
 
 ### We put these early because audit is a first match wins system.
 
-## Ignore SELinux AVC records
--a always,exclude -F msgtype=AVC
-
 ## Ignore current working directory records
 -a always,exclude -F msgtype=CWD
 


### PR DESCRIPTION
AppArmor messages are also logged as AVC messages. The current behaviour blocks them all, so no apparmor messages are printed. Change this to allow AVC.

See also: https://gitlab.com/apparmor/apparmor/-/issues/383