### PR TITLE
Update audit.rules

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -787,6 +787,15 @@
 -w /bin/sh -p x -k susp_shell
 -w /bin/ksh -p x -k susp_shell
 
+## Files viewers for potentially sensitive files
+-w /usr/bin/cat -p x -k sensitive_file_access
+-w /usr/bin/tac -p x -k sensitive_file_access
+-w /usr/bin/less -p x -k sensitive_file_access
+-w /usr/bin/more -p x -k sensitive_file_access
+-w /usr/bin/tail -p x -k sensitive_file_access
+-w /usr/bin/head -p x -k sensitive_file_access
+-w /usr/bin/nl -p x -k sensitive_file_access
+
 ## Root command executions
 -a always,exit -F arch=b64 -F euid=0 -F auid>=1000 -F auid!=-1 -S execve -k rootcmd
 


### PR DESCRIPTION
Hi,

I have added monitoring for the execution of binaries used to read files. The current configuration only logs the reading of predefined files, such as /etc/passwd (except for actions performed by the root user). For example, if we have a sensitive file located in a directory like /opt/CustomApp/Sensitive.conf, I believe the current configuration does not log this action.