### PR TITLE
network_modifications key consistency

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -226,7 +226,7 @@
 -w /etc/hosts -p wa -k network_modifications
 -w /etc/sysconfig/network -p wa -k network_modifications
 -w /etc/sysconfig/network-scripts -p w -k network_modifications
--w /etc/network/ -p wa -k network
+-w /etc/network/ -p wa -k network_modifications
 -a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k network_modifications
 
 ### Changes to issue


### PR DESCRIPTION
Modifying the key `network` to `network_modifications` so all keys related have the same name for easier SIEM rules creation