### PR TITLE
32 bit ABI

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -806,12 +806,13 @@
 -a always,exit -F arch=b64 -S rename -S renameat -S truncate -S chmod -S setxattr -S lsetxattr -S removexattr -S lremovexattr -F exit=-EACCES -k file_modification
 -a always,exit -F arch=b64 -S rename -S renameat -S truncate -S chmod -S setxattr -S lsetxattr -S removexattr -S lremovexattr -F exit=-EPERM -k file_modification
 
-## 32bit API Exploitation
+## 32bit ABI Exploitation
+### https://github.com/linux-audit/audit-userspace/blob/c014eec64b3a16c004f4a75e5792a4ac2fcc0df2/rules/21-no32bit.rules
 ### If you are on a 64 bit platform, everything _should_ be running
 ### in 64 bit mode. This rule will detect any use of the 32 bit syscalls
 ### because this might be a sign of someone exploiting a hole in the 32
-### bit API.
--a always,exit -F arch=b32 -S all -k 32bit_api
+### bit ABI.
+-a always,exit -F arch=b32 -S all -k 32bit_abi
 
 # Make The Configuration Immutable --------------------------------------------
 


### PR DESCRIPTION
The B in ABI was not a typo : 

```txt
Whereas an API defines a source interface, an ABI defines the low-level binary interface between two or more pieces of software on a particular architecture. It defines how an application interacts with itself, how an application interacts with the kernel, and how an application interacts with libraries.
```

I also added the permalink to the original audit file