### PR TITLE
Improve zypper rule: specify -p x to avoid the -p rwxa default

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -582,7 +582,7 @@
 -w /sbin/yast -p x -k software_mgmt
 -w /sbin/yast2 -p x -k software_mgmt
 -w /bin/rpm -p x -k software_mgmt
--w /usr/bin/zypper -k software_mgmt
+-w /usr/bin/zypper -p x -k software_mgmt
 
 # DPKG / APT-GET (Debian/Ubuntu)
 -w /usr/bin/dpkg -p x -k software_mgmt


### PR DESCRIPTION
This rule is supposed to log the execution of the zypper binary (the CLI package management tool on openSUSE).

However, for this rule the -p parameter is not specified, which makes auditd use its default values for -p (=rwxa). 
This leads to logging of file reads, writes and attribute changes on the zypper binary in addition to execution logging.

Suggested fix:
specify -p x for the zypper binary, so only its execution gets logged. 

Other binary execution logging rules in the ruleset specify -p x.