### PR TITLE
fix: correct binary name from aulastlogin to aulastlog

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -67,7 +67,7 @@
 -a always,exit -F path=/usr/sbin/ausearch -F perm=x -k audittools
 -a always,exit -F path=/usr/sbin/aureport -F perm=x -k audittools
 -a always,exit -F path=/usr/sbin/aulast -F perm=x -k audittools
--a always,exit -F path=/usr/sbin/aulastlogin -F perm=x -k audittools
+-a always,exit -F path=/usr/sbin/aulastlog -F perm=x -k audittools
 -a always,exit -F path=/usr/sbin/auvirt -F perm=x -k audittools
 
 # Filters ---------------------------------------------------------------------


### PR DESCRIPTION
## Bug Fix: Correct binary name from `aulastlogin` to `aulastlog`

### Problem
The rule currently references `/usr/sbin/aulastlogin` which does not 
exist on any standard Linux distribution.

### Fix
Corrected to `/usr/sbin/aulastlog` which is the actual binary shipped 
as part of the `audit` package.

### Impact
Due to this typo, the audittools rule for `aulastlog` was silently 
never matching — meaning usage of this audit tool was completely 
unmonitored.

### Verification
Run the following to confirm:
which aulastlog        # returns /usr/sbin/aulastlog ✅
which aulastlogin      # returns nothing ❌ (binary doesn't exist)

Tested on: Ubuntu 22.04, Debian 12, RHEL 9, CentOS 7/8

### Reference
- man aulastlog
- https://linux.die.net/man/8/aulastlog