### PR TITLE
Add AF_ALG telemetry for Copy Fail hunting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,38 @@ and replace `1000` in `audit.rules` before deployment:
 awk '$1=="UID_MIN" { print $2 }' /etc/login.defs
 ```
 
+## AF_ALG / Copy Fail Telemetry
+
+On April 29, 2026, Xint published Copy Fail (CVE-2026-31431), a local
+privilege-escalation technique that abuses the kernel crypto userspace
+interface (`AF_ALG`) together with `splice()` to corrupt page-cache-backed
+files in memory.
+
+This ruleset includes a small `af_alg` block to collect the stable, low-noise
+parts of that setup from attributable user sessions:
+
+- `socket(AF_ALG, ...)`
+- `bind()` using the common fixed-size `struct sockaddr_alg`
+- `setsockopt(..., SOL_ALG, ...)`
+
+This is intentionally more generic than a one-off signature for
+`authencesn(hmac(sha256),cbc(aes))` because audit syscall filters cannot match
+string arguments. In practice, the algorithm name lives in the `SOCKADDR`
+record emitted by `bind()`, so the recommended downstream detection is:
+
+- filter on `key=af_alg`
+- inspect `SOCKADDR.saddr` / `SADDR={ saddr_fam=alg ... }`
+- flag `salg_type=aead` with `salg_name` containing `authencesn(`
+- raise severity when the same `pid`, `exe`, or `auid` emits many such binds in
+  a short window
+
+The proof-of-concept described by Xint also relies on repeated `splice()`
+operations. Those syscalls are too noisy for the default ruleset on many
+systems, so the repository ships only a commented-out `splice_user` overlay in
+`audit.rules`. Enable it only if `splice` / `vmsplice` are uncommon in your
+environment and correlate it with recent `af_alg` activity from the same
+process or user session.
+
 ## Sources
 
 The configuration is based on the following sources
@@ -73,6 +105,12 @@ https://github.com/linux-audit/audit-userspace/tree/master/rules
 
 Auditd high performance linux auditing
 https://linux-audit.com/tuning-auditd-high-performance-linux-auditing/
+
+Copy Fail: 732 Bytes to Root on Every Major Linux Distribution.
+https://xint.io/blog/copy-fail-linux-distributions
+
+Linux kernel crypto userspace interface (AF_ALG)
+https://docs.kernel.org/crypto/userspace-if.html
 
 ### Further rules
 

--- a/audit.rules
+++ b/audit.rules
@@ -366,8 +366,8 @@
 -a always,exit -F arch=b32 -S acct -k process_accounting
 
 ## Kernel crypto sockets (AF_ALG)
-### Low-noise on most hosts. Copy Fail-style abuse requires AF_ALG plus
-### SOL_ALG configuration, while bind() emits a SOCKADDR record that downstream
+### Low-noise on most hosts. AF_ALG usage typically requires socket creation,
+### SOL_ALG configuration, and bind() with a SOCKADDR record that downstream
 ### tooling can decode to recover salg_type / salg_name. Audit cannot match
 ### those strings in-kernel, so keep the collection generic here.
 -a always,exit -F arch=b64 -S socket -F a0=38 -F success=1 -F auid>=1000 -F auid!=unset -k af_alg
@@ -392,7 +392,7 @@
 
 ## Optional overlay: enable only if splice/vmsplice are rare in your estate.
 ## Correlate short bursts of these events with recent af_alg activity from the
-## same pid/auid when hunting Copy Fail-style exploitation.
+## same pid/auid when investigating unusual kernel crypto socket usage.
 #-a always,exit -F arch=b64 -S splice -S vmsplice -F success=1 -F auid>=1000 -F auid!=unset -k splice_user
 #-a always,exit -F arch=b32 -S splice -S vmsplice -F success=1 -F auid>=1000 -F auid!=unset -k splice_user
 

--- a/audit.rules
+++ b/audit.rules
@@ -365,6 +365,18 @@
 -a always,exit -F arch=b64 -S acct -k process_accounting
 -a always,exit -F arch=b32 -S acct -k process_accounting
 
+## Kernel crypto sockets (AF_ALG)
+### Low-noise on most hosts. Copy Fail-style abuse requires AF_ALG plus
+### SOL_ALG configuration, while bind() emits a SOCKADDR record that downstream
+### tooling can decode to recover salg_type / salg_name. Audit cannot match
+### those strings in-kernel, so keep the collection generic here.
+-a always,exit -F arch=b64 -S socket -F a0=38 -F success=1 -F auid>=1000 -F auid!=unset -k af_alg
+-a always,exit -F arch=b32 -S socket -F a0=38 -F success=1 -F auid>=1000 -F auid!=unset -k af_alg
+-a always,exit -F arch=b64 -S bind -F a2=88 -F success=1 -F auid>=1000 -F auid!=unset -k af_alg
+-a always,exit -F arch=b32 -S bind -F a2=88 -F success=1 -F auid>=1000 -F auid!=unset -k af_alg
+-a always,exit -F arch=b64 -S setsockopt -F a1=279 -F success=1 -F auid>=1000 -F auid!=unset -k af_alg
+-a always,exit -F arch=b32 -S setsockopt -F a1=279 -F success=1 -F auid>=1000 -F auid!=unset -k af_alg
+
 ## Privilege Abuse
 ### The purpose of this rule is to detect when an admin may be abusing power by looking in user's home dir.
 -a always,exit -F dir=/home -F uid=0 -F auid>=1000 -F auid!=unset -C auid!=obj_uid -k power_abuse
@@ -377,6 +389,12 @@
 
 -a always,exit -F arch=b32 -S socket -F a0=10 -k network_socket_created
 -a always,exit -F arch=b64 -S socket -F a0=10 -k network_socket_created
+
+## Optional overlay: enable only if splice/vmsplice are rare in your estate.
+## Correlate short bursts of these events with recent af_alg activity from the
+## same pid/auid when hunting Copy Fail-style exploitation.
+#-a always,exit -F arch=b64 -S splice -S vmsplice -F success=1 -F auid>=1000 -F auid!=unset -k splice_user
+#-a always,exit -F arch=b32 -S splice -S vmsplice -F success=1 -F auid>=1000 -F auid!=unset -k splice_user
 
 # Software Management ---------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add low-noise AF_ALG audit telemetry for attributable user sessions
- document downstream correlation guidance for Copy Fail-style activity via SOCKADDR decoding
- include a commented optional splice/vmsplice overlay instead of enabling noisier defaults

## Testing
- bash scripts/lint-rules.sh audit.rules
- git diff --check